### PR TITLE
Add more names and links for the internal products in use as of 2019.

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -44,6 +44,26 @@ var RESOURCES = {
             "title": "Framework",
             "link": "https://framework.andela.com/"
         },
+        {
+            "title": "Activo",
+            "link": "https://activo.andela.com/"
+        },
+        {
+            "title": "Travela",
+            "link": "https://travela.andela.com/"
+        },
+        {
+            "title": "WatchTower",
+            "link": "https://watchtower.andela.com/"
+        },
+        {
+            "title": "Converge",
+            "link": "https://converge.andela.com/"
+        },
+        {
+            "title": "Tembea",
+            "link": "https://tembea.andela.com/"
+        }
     ],
     "external": [
         {


### PR DESCRIPTION
Add more new internal products that are in use as of 2019
 - [Activo](https://activo.andela.com/)
- [Travela](https://travela.andela.com/)
- [WatchTower](https://watchtower.andela.com/)
- [Converge](https://converge.andela.com/)
- [Tembea](https://tembea.andela.com/)